### PR TITLE
DEN-4986 [Automatic PR] Add concurrency to workflows

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,6 +17,10 @@ on:
     branches:
       - main
 
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 permissions:
   contents: read
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,10 +17,12 @@ on:
     branches:
       - main
 
-
 concurrency:
-  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+  group:
+    ${{ github.workflow }}${{ github.ref_name !=
+    github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress:
+    ${{ github.ref_name != github.event.repository.default_branch }}
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
     branches:
       - main
 
-
 concurrency:
-  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+  group:
+    ${{ github.workflow }}${{ github.ref_name !=
+    github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress:
+    ${{ github.ref_name != github.event.repository.default_branch }}
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,10 +8,12 @@ on:
     branches:
       - main
 
-
 concurrency:
-  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+  group:
+    ${{ github.workflow }}${{ github.ref_name !=
+    github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress:
+    ${{ github.ref_name != github.event.repository.default_branch }}
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
This is an automatic PR that adds concurrency to GHA workflows. As an effect there will be at most one running job __in a concurrency group__ (a branch) at any time, default branch excluded.
Optimizations like these are good for making runners available for other jobs, and will be enforced soon.

If you don't agree with these changes leave a review and raise your concern, otherwise please __merge the PR__.
